### PR TITLE
Fix inconsistent enum

### DIFF
--- a/Zydis/Zydis.Enums.pas
+++ b/Zydis/Zydis.Enums.pas
@@ -238,7 +238,7 @@ type
       // Misc registers
       'mxcsr',      'pkru',       'xcr0',       'gdtr',
       'ldtr',       'idtr',       'tr',         'bndcfg',
-      'bndstatus',  'uif' ,       'ia32_kernel_gsbase'
+      'bndstatus',  'uif' ,       'ia32_kernel_gs_base'
     );
   end;
   TZYRegister = TZYEnumRegister.Enum;


### PR DESCRIPTION
Trying to create a operand table will throw:
``` "DEFINITIONS[438].operands[6].register" contains an invalid enum value. ```
This is because enum is defined as [`ia32_kernel_gsbase` ](https://github.com/zyantific/zydis-db/blob/master/Zydis/Zydis.Enums.pas#L241) but used as `ia32_kernel_gs_base` in instructions.json.
