### PR TITLE
Changes to `--mode generate`

### DIFF
--- a/ZydisEncoder/generate_encoder_tables.py
+++ b/ZydisEncoder/generate_encoder_tables.py
@@ -2,6 +2,7 @@
 import json
 import argparse
 from instruction_manipulators import *
+from generate_encoder_types import *
 from collections import Counter, defaultdict
 from pathlib import Path
 
@@ -388,8 +389,8 @@ def get_definition(insn, allow_invisible=False):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Generates tables needed for encoder')
-    parser.add_argument('--mode', choices=['generate', 'generate-tables', 'generate-rel-info', 'generate-cc', 'stats', 'print', 'print-all', 'encodings', 'filters', 'meta'], default='generate-tables')
-    parser.add_argument('--outdir', default='')
+    parser.add_argument('--mode', choices=['generate', 'generate-tables', 'generate-rel-info', 'generate-cc', 'stats', 'print', 'print-all', 'encodings', 'filters', 'meta'], default='print')
+    parser.add_argument('--zydis-path', default=os.path.join('..', '..', 'zydis'), help='Path to Zydis repo')
     args = parser.parse_args()
 
     with open('../Data/instructions.json', 'r') as f:
@@ -536,16 +537,19 @@ if __name__ == "__main__":
             print(info)
 
         def print_file(info, filename):
-            with open(Path(args.outdir) / filename, 'w', newline='') as f:
+            with open(filename, 'w', newline='') as f:
                 f.write(info)
 
         output_function = print_file if args.mode == 'generate' else print_stdout
+        generated_path = Path(args.zydis_path) / 'src' / 'Generated'
         if tables is not None:
-            output_function(tables, 'EncoderTables.inc')
+            output_function(tables, generated_path / 'EncoderTables.inc')
         if rel_info is not None:
-            output_function(rel_info, 'GetRelInfo.inc')
+            output_function(rel_info, generated_path / 'GetRelInfo.inc')
         if cc is not None:
-            output_function(cc, 'GetCcInfo.inc')
+            output_function(cc, generated_path / 'GetCcInfo.inc')
+        if args.mode == 'generate':
+            parse_zydis_types(args.zydis_path)
     elif args.mode == 'stats':
         print('max_args=%d' % max_args)
         print('max_visible_args=%d' % max_visible_args)

--- a/ZydisEncoder/generate_encoder_types.py
+++ b/ZydisEncoder/generate_encoder_types.py
@@ -61,7 +61,7 @@ class ZydisPreprocessor(Preprocessor):
         generated_type = "%s = IntFlag('%s', [\n" % (name, name)
         values = [
             (k, self.expand_macro(v).replace('ULL', '').replace('u', ''))
-            for k, v in preprocessor.macros.items()
+            for k, v in self.macros.items()
             if k.startswith(prefix)
         ]
         values.sort(key=lambda x: eval(x[1]))
@@ -144,13 +144,9 @@ class ZydisParser:
         return types
 
 
-if __name__ == "__main__":
-    arg_parser = argparse.ArgumentParser(description='Generates python versions of Zydis types from C sources')
-    arg_parser.add_argument('zydis_path', nargs='?', default=os.path.join('..', '..', 'zydis'), help='Path to Zydis repository')
-    args = arg_parser.parse_args()
-
+def parse_zydis_types(zydis_path):
     # Preprocess Zydis sources for parsing
-    preprocessor = ZydisPreprocessor(args.zydis_path)
+    preprocessor = ZydisPreprocessor(zydis_path)
     encoder_file = preprocessor.get_preprocessed_file()
 
     # Extract important #define constants
@@ -186,7 +182,7 @@ if __name__ == "__main__":
     ])
 
     # Save generated file
-    with open(os.path.join(args.zydis_path, 'tests', 'zydis_encoder_types.py'), 'w', newline='') as f:
+    with open(os.path.join(zydis_path, 'tests', 'zydis_encoder_types.py'), 'w', newline='') as f:
         f.write("""#!/usr/bin/env python3
 from enum import IntEnum, IntFlag
 
@@ -198,3 +194,10 @@ ZYDIS_DECODER_MODE_KNC = 2  # Must be updated manually if ZydisDecoderMode chang
         f.write(zydis_default_flags)
         f.write(zydis_encodable_prefixes)
         f.write(enums)
+
+
+if __name__ == "__main__":
+    arg_parser = argparse.ArgumentParser(description='Generates python versions of Zydis types from C sources')
+    arg_parser.add_argument('zydis_path', nargs='?', default=os.path.join('..', '..', 'zydis'), help='Path to Zydis repository')
+    args = arg_parser.parse_args()
+    parse_zydis_types(args.zydis_path)


### PR DESCRIPTION
Now using
`py generate_encoder_tables.py --mode generate --zydis-path <path to zydis repo, default is ../../zydis>` will regenerate all `*.inc` files and `zydis_encoder_types.py`.