### PR TITLE
Generate new ZydisShortStrings with prepended length

### DIFF
--- a/scripts/gen_registers.py
+++ b/scripts/gen_registers.py
@@ -3,6 +3,7 @@
 
 import json
 import os
+import sys
 
 class _JsonRegisterClass():
 
@@ -98,7 +99,7 @@ class _ZydisEnumWriter():
 
 class _ZydisTableWriter():
     def __init__(self, symbol_name, item_type, file_name, is_static=True, is_const=True, indent=4):
-        self.__file_name = file_name
+        self._file_name = file_name
         self.__symbol_name = symbol_name
         self.__item_type = item_type
         self.__static = 'static ' if is_static else ''
@@ -107,7 +108,7 @@ class _ZydisTableWriter():
         self.__expect_delim = False
         
     def __enter__(self):
-        self.__f = open(self.__file_name, 'w')
+        self._f = open(self._file_name, 'w')
         self.__emit_header()
         return self
 
@@ -115,7 +116,7 @@ class _ZydisTableWriter():
         if exc_type is not None:
             return False
         self.__emit_footer()
-        self.__f.close()
+        self._f.close()
         return True
 
     def __emit_header(self):
@@ -128,55 +129,69 @@ class _ZydisTableWriter():
             item_type = self.__item_type,
             symbol_name = self.__symbol_name
         )
-        self.__f.write(header)
+        self._f.write(header)
 
     def __emit_footer(self):
         footer = (
             '\n};\n'
         )
-        self.__f.write(footer)
+        self._f.write(footer)
 
     def __emit_delim(self):
         if self.__expect_delim:
-            self.__f.write(',\n')
+            self._f.write(',\n')
 
     def emit_value(self, value):
         self.__emit_delim()
-        self.__f.write('{indent}{value}'.format(
-            indent = self.__indent, 
+        self._f.write('{indent}{value}'.format(
+            indent = self.__indent,
             value = value
         ))
         self.__expect_delim = True
 
-    def emit_comment(self, comment):
+    def emit_comment(self, comment, indent=None):
         self.__emit_delim()
-        self.__f.write('{indent}// {comment}\n'.format(
-            indent = self.__indent, 
+        self._f.write('{indent}// {comment}\n'.format(
+            indent = indent if indent is not None else self.__indent,
             comment = comment
         ))
         self.__expect_delim = False
 
     def emit_newline(self):
         self.__emit_delim()
-        self.__f.write('\n')
-        self.__expect_delim = False 
+        self._f.write('\n')
+        self.__expect_delim = False
 
-class _ZydisStringTableWriter(_ZydisTableWriter):
+class _ZydisShortStringTableWriter(_ZydisTableWriter):
 
-    def __init__(self, symbol_name, make_shortstrings, file_name, indent=4):
-        item_type = 'ZydisShortString' if make_shortstrings else 'char*'
-        super().__init__(symbol_name, item_type, file_name, True, True, indent)
-        self.__make_shortstrings = make_shortstrings
-        
+    def __init__(self, symbol_name, file_name, indent=4):
+        super().__init__(symbol_name, 'ZydisShortString*', file_name, True, True, indent)
+        self.__symbol_name = symbol_name
+        self.__values_count = 0
+
+    def __value_symbol_name(self, i):
+        return f'{self.__symbol_name}_VALUE_{i}'
+
+    def __enter__(self):
+        self._f = open(self._file_name, 'w')
+        return self
+
+    def __exit__(self, exc_type, exc_value, tb):
+        self._f.write('\n')
+        self._ZydisTableWriter__emit_header()
+        for i in range(self.__values_count):
+            super().emit_value(f'&{self.__value_symbol_name(i)}')
+        return super().__exit__(exc_type, exc_value, tb)
+
     def emit_value(self, value):
-        value = '"{value}"'.format(
+        self._f.write('static const ZydisShortString {sym} = ZYDIS_MAKE_SHORTSTRING("{value}");\n'.format(
+            sym = self.__value_symbol_name(self.__values_count),
             value = value.lower()
-        )
-        if self.__make_shortstrings:
-            value = 'ZYDIS_MAKE_SHORTSTRING({value})'.format(
-                value = value
-            )
-        super().emit_value(value) 
+        ))
+        self.__values_count += 1
+
+    def emit_comment(self, comment, indent=None):
+        super().emit_comment(comment, indent=indent if indent is not None else '')
 
 class Generator():
 
@@ -195,8 +210,8 @@ class Generator():
         fn_enum = os.path.join(output_dir, 'include/Zydis/Generated/EnumRegister.h')
         fn_enum_strings = os.path.join(output_dir, 'src/Generated/EnumRegister.inc')
         with (
-            _ZydisEnumWriter('Register', 'REGISTER', fn_enum) as w_enum, 
-            _ZydisStringTableWriter('STR_REGISTERS', True, fn_enum_strings) as w_enum_strings
+            _ZydisEnumWriter('Register', 'REGISTER', fn_enum) as w_enum,
+            _ZydisShortStringTableWriter('STR_REGISTERS', fn_enum_strings) as w_enum_strings
         ):
             w_enum.emit_value('none')
             w_enum_strings.emit_value('none')
@@ -267,6 +282,10 @@ class Generator():
                     width = width,
                     width_64 = width_64
                 ))
-              
-generator = Generator('./Data/registers.json')
-generator.generate('D:/Development/GitHub/zydis/')
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        sys.stderr.write(f"usage: {sys.argv[0]} [datafiles/registers.json] [path/to/zydis/]")
+        sys.exit(1)
+    generator = Generator(sys.argv[1])
+    generator.generate(sys.argv[2])

--- a/src/Zydis.Generator.Core/CodeGeneration/DeclarationWriter.cs
+++ b/src/Zydis.Generator.Core/CodeGeneration/DeclarationWriter.cs
@@ -108,11 +108,15 @@ public sealed class DeclarationWriter
 
     public InitializerListWriter WriteInitializerList(bool indent = IndentByDefault)
     {
-        _writer.Write(" = ");
+        _writer.Write(" =");
 
         if (_indented)
         {
             _writer.WriteLine();
+        }
+        else
+        {
+            _writer.Write(" ");
         }
 
         return new InitializerListWriter(_writer, _indented && indent ? IndentSize : null);

--- a/src/Zydis.Generator.Core/CodeGeneration/DeclarationWriter.cs
+++ b/src/Zydis.Generator.Core/CodeGeneration/DeclarationWriter.cs
@@ -95,6 +95,16 @@ public sealed class DeclarationWriter
         return this;
     }
 
+    public DeclarationWriter WriteInitializerZydisShortString(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        _writer.Write(" = ");
+        WriterExtensions.WriteZydisShortString(_writer, value);
+
+        return this;
+    }
+
     public DeclarationWriter WriteInitializerValue<TValue>(IBinaryInteger<TValue> value, int length = 0, bool hex = false)
         where TValue : struct, IBinaryInteger<TValue>
     {

--- a/src/Zydis.Generator.Core/CodeGeneration/InitializerListWriter.cs
+++ b/src/Zydis.Generator.Core/CodeGeneration/InitializerListWriter.cs
@@ -117,6 +117,20 @@ public sealed class InitializerListWriter
         return this;
     }
 
+    public InitializerListWriter WriteZydisShortString(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        EnsureDelimiter();
+
+        WriterExtensions.WriteZydisShortString(_writer, value);
+        _lastTokenIsExpression = true;
+
+        EnsureMacroParenthesis();
+
+        return this;
+    }
+
     public InitializerListWriter WriteInteger<TValue>(IBinaryInteger<TValue> value, int length = 0, bool hex = false)
         where TValue : struct, IBinaryInteger<TValue>
     {

--- a/src/Zydis.Generator.Core/CodeGeneration/WriterExtensions.cs
+++ b/src/Zydis.Generator.Core/CodeGeneration/WriterExtensions.cs
@@ -25,6 +25,13 @@ internal static class WriterExtensions
         writer.Write("\"{0}\"", value);
     }
 
+    public static void WriteZydisShortString(TextWriter writer, string value)
+    {
+        writer.Write("ZYDIS_MAKE_SHORTSTRING(");
+        WriteString(writer, value);
+        writer.Write(")");
+    }
+
     public static void WriteInteger<TValue>(TextWriter writer, IBinaryInteger<TValue> value, int length, bool hex)
         where TValue : struct, IBinaryInteger<TValue>
     {

--- a/src/Zydis.Generator.Core/Definitions/Builder/DefinitionRegistry.cs
+++ b/src/Zydis.Generator.Core/Definitions/Builder/DefinitionRegistry.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -12,13 +13,14 @@ namespace Zydis.Generator.Core.Definitions.Builder;
 /// Maintains a collection of instruction definitions per encoding while ensuring a deterministic order.
 /// Deduplicates definitions during insertion.
 /// </summary>
-internal sealed class DefinitionRegistry
+internal sealed class DefinitionRegistry: IEnumerable<InstructionDefinition>
 {
     private static readonly SortedDictionary<InstructionDefinition, int> Empty = new(InstructionDefinitionTableComparer.Instance);
 
-    private readonly Dictionary<InstructionEncoding, SortedDictionary<InstructionDefinition, int>> _instructions = new();
+    private readonly SortedSet<InstructionDefinition> _instructions = new(InstructionDefinitionTableComparer.Instance);
+    private readonly Dictionary<InstructionEncoding, SortedDictionary<InstructionDefinition, int>> _encodingInstructions = new();
 
-    public IEnumerable<InstructionDefinition> this[InstructionEncoding encoding] => _instructions.GetValueOrDefault(encoding, Empty).Keys;
+    public IEnumerable<InstructionDefinition> this[InstructionEncoding encoding] => _encodingInstructions.GetValueOrDefault(encoding, Empty).Keys;
 
     /// <summary>
     /// Retrieves the unique identifier for the specified instruction definition.
@@ -30,7 +32,7 @@ internal sealed class DefinitionRegistry
     {
         ArgumentNullException.ThrowIfNull(definition);
 
-        if (!_instructions.TryGetValue(definition.Encoding, out var instructions))
+        if (!_encodingInstructions.TryGetValue(definition.Encoding, out var instructions))
         {
             throw new ArgumentException("Unknown instruction encoding.", nameof(definition));
         }
@@ -55,10 +57,10 @@ internal sealed class DefinitionRegistry
     {
         ArgumentNullException.ThrowIfNull(definition);
 
-        if (!_instructions.TryGetValue(definition.Encoding, out var instructions))
+        if (!_encodingInstructions.TryGetValue(definition.Encoding, out var instructions))
         {
             instructions = new SortedDictionary<InstructionDefinition, int>(InstructionDefinitionTableComparer.Instance);
-            _instructions.Add(definition.Encoding, instructions);
+            _encodingInstructions.Add(definition.Encoding, instructions);
         }
 
         if (instructions.ContainsKey(definition))
@@ -66,7 +68,18 @@ internal sealed class DefinitionRegistry
             return;
         }
 
+        _instructions.Add(definition);
         instructions.Add(definition, instructions.Count);
+    }
+
+    public IEnumerator<InstructionDefinition> GetEnumerator()
+    {
+        return _instructions.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
     }
 }
 

--- a/src/Zydis.Generator.Core/Definitions/Emitters/EnumEmitter.cs
+++ b/src/Zydis.Generator.Core/Definitions/Emitters/EnumEmitter.cs
@@ -44,26 +44,49 @@ typedef enum Zydis{enumName}_
 
     public async Task EmitStringsAsync(StreamWriter writer, bool useInternalStringType)
     {
-        var declarationWriter = new DeclarationWriter(writer, true);
-        declarationWriter
+        string ShortStringName(int index)
+        {
+            return $"STR_{enumName.ToUpperInvariant()}_VALUE_{index}";
+        }
+
+        var index = 0;
+        if (useInternalStringType)
+        {
+            var valueDeclarationWriter = new DeclarationWriter(writer, false);
+            foreach (var item in items)
+            {
+                valueDeclarationWriter
+                    .BeginDeclaration("static const", "ZydisShortString", ShortStringName(index))
+                    .WriteInitializerZydisShortString(item)
+                    .EndDeclaration()
+                    .WriteNewline();
+                index++;
+            }
+            valueDeclarationWriter.WriteNewline();
+        }
+
+        var tableDeclarationWriter = new DeclarationWriter(writer, true);
+        tableDeclarationWriter
             .BeginDeclaration(
                 "static const",
-                useInternalStringType ? "ZydisShortString" : "char*",
+                useInternalStringType ? "ZydisShortString*" : "char*",
                 $"STR_{enumName.ToUpperInvariant()}[]");
-        var initializerListWriter = declarationWriter.WriteInitializerList().BeginList();
+        var initializerListWriter = tableDeclarationWriter.WriteInitializerList().BeginList();
+        index = 0;
         foreach (var item in items)
         {
             if (useInternalStringType)
             {
-                initializerListWriter.WriteZydisShortString(item);
+                initializerListWriter.WriteExpression($"&{ShortStringName(index)}");
             }
             else
             {
                 initializerListWriter.WriteString(item);
             }
+            index++;
         }
         initializerListWriter.EndList();
-        declarationWriter.EndDeclaration();
+        tableDeclarationWriter.EndDeclaration();
         await writer.WriteLineAsync().ConfigureAwait(false);
     }
 }

--- a/src/Zydis.Generator.Core/Definitions/Emitters/EnumEmitter.cs
+++ b/src/Zydis.Generator.Core/Definitions/Emitters/EnumEmitter.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Zydis.Generator.Core.CodeGeneration;
+
+namespace Zydis.Generator.Core.Definitions.Emitters;
+
+internal class EnumEmitter(string enumName, string prefix, IEnumerable<string> items)
+{
+    /*private string _enumName;
+    private SortedSet<string> _items;
+
+    public EnumEmitter(string enumName, IEnumerable<string> items)
+    {
+        _enumName = enumName;
+        _items = [..items];
+    }*/
+
+
+    public async Task EmitDefinitionAsync(StreamWriter writer)
+    {
+        await writer.WriteLineAsync($@"/**
+ * Defines the `Zydis{enumName}` enum.
+ */
+typedef enum Zydis{enumName}_
+{{").ConfigureAwait(false);
+        foreach (var item in items)
+        {
+            await writer.WriteLineAsync($"    ZYDIS_{prefix}_{item.ToUpperInvariant()},").ConfigureAwait(false);
+        }
+        await writer.WriteLineAsync($@"
+    /**
+     * Maximum value of this enum.
+     */
+    ZYDIS_{prefix}_MAX_VALUE = ZYDIS_{prefix}_{items.Last().ToUpperInvariant()},
+    /**
+     * The minimum number of bits required to represent all values of this enum.
+     */
+    ZYDIS_{prefix}_REQUIRED_BITS = ZYAN_BITS_TO_REPRESENT(ZYDIS_{prefix}_MAX_VALUE)
+}} Zydis{enumName};").ConfigureAwait(false);
+    }
+
+    public async Task EmitStringsAsync(StreamWriter writer, bool useInternalStringType)
+    {
+        var declarationWriter = new DeclarationWriter(writer, true);
+        declarationWriter
+            .BeginDeclaration(
+                "static const",
+                useInternalStringType ? "ZydisShortString" : "char*",
+                $"STR_{enumName.ToUpperInvariant()}[]");
+        var initializerListWriter = declarationWriter.WriteInitializerList().BeginList();
+        foreach (var item in items)
+        {
+            if (useInternalStringType)
+            {
+                initializerListWriter.WriteZydisShortString(item);
+            }
+            else
+            {
+                initializerListWriter.WriteString(item);
+            }
+        }
+        initializerListWriter.EndList();
+        declarationWriter.EndDeclaration();
+        await writer.WriteLineAsync().ConfigureAwait(false);
+    }
+}

--- a/src/Zydis.Generator.Core/ZydisGenerator.cs
+++ b/src/Zydis.Generator.Core/ZydisGenerator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -69,6 +70,7 @@ public sealed class ZydisGenerator
         var statistics = new DecoderTableEmitterStatistics();
         var utf8 = new UTF8Encoding(false);
         var generatedSourcesPath = Path.Combine(outputDirectory, "src", "Generated");
+        var generatedIncludePath = Path.Combine(outputDirectory, "include", "Zydis", "Generated");
 
         await using var tableWriter = new StreamWriter(Path.Combine(generatedSourcesPath, "DecoderTables.inc"), false, utf8); // TODO: ConfigureAwait
 
@@ -104,6 +106,43 @@ public sealed class ZydisGenerator
         await using var relativeInfoWriter = new StreamWriter(Path.Combine(generatedSourcesPath, "GetRelInfo.inc"), false, utf8);
 
         await RelativeInfoEmitter.EmitAsync(relativeInfoWriter, _relativeInfoRegistry).ConfigureAwait(false);
+
+        async Task GenerateEnum(string enumName, string prefix, bool useInternalStringType, IEnumerable<string> items, string invalidValue)
+        {
+            var emitter = new EnumEmitter(enumName, prefix, new SortedSet<string>(items).Prepend(invalidValue));
+            await using var enumDefWriter = new StreamWriter(Path.Combine(generatedIncludePath, $"Enum{enumName}.h"), false, utf8);
+            await emitter.EmitDefinitionAsync(enumDefWriter).ConfigureAwait(false);
+            await using var enumStringsWriter = new StreamWriter(Path.Combine(generatedSourcesPath, $"Enum{enumName}.inc"), false, utf8);
+            await emitter.EmitStringsAsync(enumStringsWriter, useInternalStringType).ConfigureAwait(false);
+        }
+        await GenerateEnum(
+            "Mnemonic",
+            "MNEMONIC",
+            true,
+            _definitionRegistry.Select(definition => definition.Mnemonic),
+            "invalid"
+        ).ConfigureAwait(false);
+        await GenerateEnum(
+            "InstructionCategory",
+            "CATEGORY",
+            false,
+            _definitionRegistry.Select(definition => definition.MetaInfo.Category),
+            "INVALID"
+        ).ConfigureAwait(false);
+        await GenerateEnum(
+            "ISASet",
+            "ISA_SET",
+            false,
+            _definitionRegistry.Select(definition => definition.MetaInfo.IsaSet),
+            "INVALID"
+        ).ConfigureAwait(false);
+        await GenerateEnum(
+            "ISAExt",
+            "ISA_EXT",
+            false,
+            _definitionRegistry.Select(definition => definition.MetaInfo.IsaExtension),
+            "INVALID"
+        ).ConfigureAwait(false);
     }
 
     private async Task GenerateOpcodeTables(StreamWriter writer, DecoderTableEmitterStatistics statistics)


### PR DESCRIPTION
This corresponds to https://github.com/zyantific/zydis/pull/604

The first commit here is only adding enum generation to the C# generator, with the old Delphi implementation as the reference. A small change is that some trailing spaces have been removed, which causes diffs also in files other than the `Enum*` ones.

The second commit adapts to the new `ZydisShortStrings` format.

I considered also porting the register enum generation from Python to C#, but this would have needed porting also the parsing of register definitions first and I already had a working prototype change for the Python script.