### PR TITLE
Add FormatterStrings.inc generation

### DIFF
--- a/datafiles/shared_enums.json
+++ b/datafiles/shared_enums.json
@@ -333,5 +333,56 @@
       }
     ],
     "is_serializable": true
+  },
+  {
+    "name": "token_type::TOKEN",
+    "members": [
+      {
+        "name": "invalid"
+      },
+      {
+        "name": "whitespace"
+      },
+      {
+        "name": "delimiter"
+      },
+      {
+        "name": "parenthesis_open"
+      },
+      {
+        "name": "parenthesis_close"
+      },
+      {
+        "name": "prefix"
+      },
+      {
+        "name": "mnemonic"
+      },
+      {
+        "name": "register"
+      },
+      {
+        "name": "address_abs"
+      },
+      {
+        "name": "address_rel"
+      },
+      {
+        "name": "displacement"
+      },
+      {
+        "name": "immediate"
+      },
+      {
+        "name": "typecast"
+      },
+      {
+        "name": "decorator"
+      },
+      {
+        "name": "symbol"
+      }
+    ],
+    "is_serializable": true
   }
 ]

--- a/src/Zydis.Generator.Core/CodeGeneration/WriterExtensions.cs
+++ b/src/Zydis.Generator.Core/CodeGeneration/WriterExtensions.cs
@@ -17,7 +17,11 @@ internal static class WriterExtensions
 
     public static void WriteChar(TextWriter writer, char value)
     {
-        writer.Write("'{0}'", value);
+        writer.Write("'{0}'", value switch
+        {
+            '\0' => "\\0",
+            _ => value
+        });
     }
 
     public static void WriteString(TextWriter writer, string value)

--- a/src/Zydis.Generator.Core/Definitions/Builder/FormatterStringsRegistry.cs
+++ b/src/Zydis.Generator.Core/Definitions/Builder/FormatterStringsRegistry.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Zydis.Generator.Core.Serialization;
+
+namespace Zydis.Generator.Core.Definitions.Builder;
+
+public class FormatterStringsRegistry
+{
+    public readonly List<FormatterStringDefinition> Definitions = [];
+
+    public async Task ReadAsync(string filename, CancellationToken cancellationToken = default)
+    {
+        await foreach (var definition in DefinitionReader.ReadAsync<FormatterStringDefinition>(filename, cancellationToken).ConfigureAwait(false))
+        {
+            Definitions.Add(definition);
+        }
+    }
+}

--- a/src/Zydis.Generator.Core/Definitions/Emitters/EnumEmitter.cs
+++ b/src/Zydis.Generator.Core/Definitions/Emitters/EnumEmitter.cs
@@ -9,16 +9,6 @@ namespace Zydis.Generator.Core.Definitions.Emitters;
 
 internal class EnumEmitter(string enumName, string prefix, IEnumerable<string> items)
 {
-    /*private string _enumName;
-    private SortedSet<string> _items;
-
-    public EnumEmitter(string enumName, IEnumerable<string> items)
-    {
-        _enumName = enumName;
-        _items = [..items];
-    }*/
-
-
     public async Task EmitDefinitionAsync(StreamWriter writer)
     {
         await writer.WriteLineAsync($@"/**

--- a/src/Zydis.Generator.Core/Definitions/Emitters/FormatterStringsEmitter.cs
+++ b/src/Zydis.Generator.Core/Definitions/Emitters/FormatterStringsEmitter.cs
@@ -1,0 +1,78 @@
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Zydis.Generator.Core.CodeGeneration;
+using Zydis.Generator.Core.Definitions.Builder;
+using Zydis.Generator.Enums;
+
+namespace Zydis.Generator.Core.Definitions.Emitters;
+
+internal static class FormatterStringsEmitter
+{
+    public static async Task EmitAsync(StreamWriter writer, FormatterStringsRegistry registry)
+    {
+        await writer.WriteLineAsync("#pragma pack(push, 1)\n").ConfigureAwait(false);
+
+        var declarationWriter = DeclarationWriter.Create(writer, false);
+        foreach (var definition in registry.Definitions)
+        {
+            var cName = definition.Name.ToUpperInvariant();
+            var fullString = definition.FullString;
+            Debug.Assert(fullString != null, "definition.FullString != null");
+            declarationWriter
+                .BeginDeclaration("static const", "ZydisShortString", $"STR_{cName}")
+                .WriteInitializerZydisShortString(fullString)
+                .EndDeclaration();
+            await writer.WriteLineAsync().ConfigureAwait(false);
+
+            var tokens = definition.Tokens;
+            if (tokens != null && tokens.Length > 0)
+            {
+                // size per token:
+                //  - 1 byte for type
+                //  - 1 byte for length of the token
+                //  - n bytes for token string contents
+                //  - 1 byte for zero-termination
+                var size = tokens.Length * 3 + fullString.Length;
+                var initializerListWriter = declarationWriter.BeginDeclaration("static const", $@"struct ZydisPredefinedToken{cName}_
+{{
+  ZyanU8 size;
+  ZyanU8 next;
+  ZyanU8 data[{size}];
+}}", $"TOK_DATA_{cName}")
+                    .WriteInitializerList(false)
+                    .BeginList()
+                    .WriteInteger(size) // size
+                    .WriteInteger(size - tokens.Last().Value.Length - 1); // next (offset to the string of the last token)
+                var tokenListWriter = initializerListWriter
+                    .WriteInitializerList()
+                    .BeginList();
+                var i = 0;
+                foreach (var token in tokens)
+                {
+                    tokenListWriter
+                        .WriteExpression(token.Type.ToZydisString()) // ZydisFormatterToken.type
+                        .WriteInteger(i + 1 == tokens.Length ? 0 : token.Value.Length + 1); // ZydisFormatterToken.next
+                    foreach (var ch in token.Value)
+                    {
+                        tokenListWriter.WriteChar(ch);
+                    }
+                    tokenListWriter.WriteChar('\0');
+                    i++;
+                }
+                tokenListWriter.EndList();
+                initializerListWriter.EndList();
+                declarationWriter.EndDeclaration();
+                await writer.WriteLineAsync().ConfigureAwait(false);
+                declarationWriter.BeginDeclaration("static const", "ZydisPredefinedToken* const", $"TOK_{cName}")
+                    .WriteInitializerExpression($"(const ZydisPredefinedToken* const)&TOK_DATA_{cName}")
+                    .EndDeclaration();
+                await writer.WriteLineAsync().ConfigureAwait(false);
+                await writer.WriteLineAsync().ConfigureAwait(false);
+            }
+        }
+
+        await writer.WriteLineAsync("#pragma pack(pop)").ConfigureAwait(false);
+    }
+}

--- a/src/Zydis.Generator.Core/Definitions/FormatterStringDefinition.cs
+++ b/src/Zydis.Generator.Core/Definitions/FormatterStringDefinition.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Linq;
+using System.Text.Json.Serialization;
+using Zydis.Generator.Enums;
+
+namespace Zydis.Generator.Core.Definitions;
+
+public sealed record FormatterStringToken
+{
+    [JsonPropertyName("value")]
+    public required string Value { get; init; }
+
+    [JsonPropertyName("type")]
+    public required TokenType Type { get; init; }
+}
+
+public sealed record FormatterStringDefinition
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("tokens")]
+    public FormatterStringToken[]? Tokens { get; init; }
+
+    [JsonPropertyName("string")]
+    public string? StringLiteral { get; init; }
+
+    public string? FullString
+    {
+        get
+        {
+            if (Tokens != null)
+            {
+                return String.Join("", Tokens.Select(x => x.Value));
+            }
+            return StringLiteral;
+        }
+    }
+}

--- a/src/Zydis.Generator.Core/Serialization/DefinitionReader.cs
+++ b/src/Zydis.Generator.Core/Serialization/DefinitionReader.cs
@@ -24,7 +24,7 @@ public static partial class DefinitionReader
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault
     };
 
-    public static async IAsyncEnumerable<InstructionDefinition> ReadAsync(string filename, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public static async IAsyncEnumerable<T> ReadAsync<T>(string filename, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrEmpty(filename);
 
@@ -33,7 +33,7 @@ public static partial class DefinitionReader
             .ConfigureAwait(false);
 
         var items = JsonSerializer
-            .DeserializeAsyncEnumerable<InstructionDefinition>(fs, SerializerOptions, cancellationToken)
+            .DeserializeAsyncEnumerable<T>(fs, SerializerOptions, cancellationToken)
             .ConfigureAwait(false);
 
         await foreach (var item in items)
@@ -52,6 +52,7 @@ public static partial class DefinitionReader
     [JsonSerializable(typeof(InstructionFlagsAccess))]
     [JsonSerializable(typeof(InstructionFlag))]
     [JsonSerializable(typeof(InstructionFlagOperation))]
+    [JsonSerializable(typeof(FormatterStringDefinition))]
     private sealed partial class SerializerContext :
         JsonSerializerContext
     {

--- a/src/Zydis.Generator.Core/ZydisGenerator.cs
+++ b/src/Zydis.Generator.Core/ZydisGenerator.cs
@@ -10,6 +10,7 @@ using Zydis.Generator.Core.CodeGeneration;
 using Zydis.Generator.Core.Common;
 using Zydis.Generator.Core.DecoderTree.Builder;
 using Zydis.Generator.Core.DecoderTree.Emitters;
+using Zydis.Generator.Core.Definitions;
 using Zydis.Generator.Core.Definitions.Builder;
 using Zydis.Generator.Core.Definitions.Emitters;
 using Zydis.Generator.Core.Serialization;
@@ -27,12 +28,13 @@ public sealed class ZydisGenerator
     private readonly EncoderDefinitionRegistry _encoderRegistry = new();
     private readonly ConditionCodeRegistry _conditionCodeRegistry = new();
     private readonly RelativeInfoRegistry _relativeInfoRegistry = new();
+    private readonly FormatterStringsRegistry _formatterStringsRegistry = new();
 
-    public async Task ReadDefinitionsAsync(string filename, CancellationToken cancellationToken = default)
+    public async Task ReadDefinitionsAsync(string datafilesPath, CancellationToken cancellationToken = default)
     {
-        ArgumentException.ThrowIfNullOrEmpty(filename);
+        ArgumentException.ThrowIfNullOrEmpty(datafilesPath);
 
-        await foreach (var definition in DefinitionReader.ReadAsync(filename, cancellationToken).ConfigureAwait(false))
+        await foreach (var definition in DefinitionReader.ReadAsync<InstructionDefinition>(Path.Join(datafilesPath, "instructions.json"), cancellationToken).ConfigureAwait(false))
         {
             _definitionRegistry.InsertDefinition(definition);
             _decoderTreeBuilder.InsertDefinition(definition);
@@ -56,6 +58,8 @@ public sealed class ZydisGenerator
 
         //var emitter = new OpcodeTableConsoleEmitter(_definitionRegistry, _encodingRegistry, null);
         //emitter.Emit(_decoderTreeBuilder.OpcodeTables.GetTable(InstructionEncoding.Default, OpcodeMap.MAP0, null));
+
+        await _formatterStringsRegistry.ReadAsync(Path.Join(datafilesPath, "formatter_strings.json"), cancellationToken);
     }
 
     public async Task GenerateDataTablesAsync(string outputDirectory, CancellationToken cancellationToken = default)
@@ -143,6 +147,9 @@ public sealed class ZydisGenerator
             _definitionRegistry.Select(definition => definition.MetaInfo.IsaExtension),
             "INVALID"
         ).ConfigureAwait(false);
+
+        await using var formatterStringsWriter = new StreamWriter(Path.Combine(generatedSourcesPath, "FormatterStrings.inc"));
+        await FormatterStringsEmitter.EmitAsync(formatterStringsWriter, _formatterStringsRegistry).ConfigureAwait(false);
     }
 
     private async Task GenerateOpcodeTables(StreamWriter writer, DecoderTableEmitterStatistics statistics)

--- a/src/Zydis.Generator/Program.cs
+++ b/src/Zydis.Generator/Program.cs
@@ -6,8 +6,14 @@ namespace Zydis.Generator;
 
 internal sealed class Program
 {
-    private static async Task Main(string[] args)
+    private static async Task<int> Main(string[] args)
     {
+        if (args.Length != 2)
+        {
+            await System.Console.Error.WriteLineAsync("usage: Zydis.Generator [path/to/datafiles/] [path/to/zydis/]").ConfigureAwait(false);
+            return 1;
+        }
+
         var generator = new ZydisGenerator();
 
         await generator.ReadDefinitionsAsync(args[0]).ConfigureAwait(false);
@@ -16,5 +22,6 @@ internal sealed class Program
 
         //var emitter = new DecoderTableConsoleEmitter{ SkipEmpty = true };
         //emitter.Emit(builder.OpcodeTables.GetTable(InstructionEncoding.VEX, OpcodeMap.M0F, RefiningPrefix.P66));
+        return 0;
     }
 }


### PR DESCRIPTION
Command-line arguments of the parser are changed to take the path to datafiles/ instead of datafiles/instructions.json as more files are read from there now.

This generates 1:1 these contents: https://github.com/zyantific/zydis/blob/299facc420063ffb5d42d65e8cf81372ccefa8aa/src/Generated/FormatterStrings.inc

It is for https://github.com/zyantific/zydis/pull/604, since `FormatterStrings.inc` will likely need some changes, which can then be implemented on top of this generator.