### PR TITLE
Fixed flag register access for TestedModified flags

### DIFF
--- a/src/Zydis.Generator.Core/Definitions/InstructionFlags.cs
+++ b/src/Zydis.Generator.Core/Definitions/InstructionFlags.cs
@@ -63,7 +63,6 @@ public sealed record InstructionFlags :
             if (operation is InstructionFlagOperation.Tested or InstructionFlagOperation.TestedModified)
             {
                 doesRead = true;
-                continue;
             }
 
             if (operation is InstructionFlagOperation.TestedModified


### PR DESCRIPTION
Fixes `EFLAGS`/`RFLAGS` operand being marked as just "read" for `cmc`, `adcx` and `adox`.