### PR TITLE
Fix implicit pointer register operands of string instructions

### DIFF
--- a/src/Zydis.Generator.Core/Definitions/OperandAccess.cs
+++ b/src/Zydis.Generator.Core/Definitions/OperandAccess.cs
@@ -48,7 +48,13 @@ public enum OperandAccess
     /// The operand is only read conditionally but always written.
     /// </summary>
     [JsonStringEnumMemberName("condread_write")]
-    CondReadWrite
+    CondReadWrite,
+
+    /// <summary>
+    /// The operand is conditionally read and conditionally written.
+    /// </summary>
+    [JsonStringEnumMemberName("condread_condwrite")]
+    CondReadCondWrite
 }
 
 public static class OperandAccessExtensions
@@ -64,6 +70,7 @@ public static class OperandAccessExtensions
             OperandAccess.CondWrite => "CONDWRITE",
             OperandAccess.ReadCondWrite => "READ_CONDWRITE",
             OperandAccess.CondReadWrite => "CONDREAD_WRITE",
+            OperandAccess.CondReadCondWrite => "CONDREAD_CONDWRITE",
             _ => throw new ArgumentOutOfRangeException(nameof(value), value, null)
         };
     }


### PR DESCRIPTION
## Summary

Corrects the implicit SI/DI pointer register operands of the x86 string instructions (`movs`, `stos`, `lods`, `cmps`, `scas`, `ins`, `outs`).

## Changes

- Non-REP `lods` forms now report SI as unconditionally read/written (`read_write`), matching `movs` and `stos`.
- `cmps`, `scas`, `ins` and `outs` were missing their implicit SI/DI register operands entirely; they are now present on every prefix form.
- The REP (`f3`/`f2`) forms of all string families now report SI/DI as `condread_condwrite`: with REP and CX=0 the pointer registers are neither read nor written, so conditional-read-plus-conditional-write is the accurate access type. This access type (`ZYDIS_OPERAND_ACTION_CONDREAD_CONDWRITE`) is already defined by Zydis; generator support for it (`OperandAccess.CondReadCondWrite`) is added alongside the data change.