### PR TITLE
Correct BF16 operand element types

### DIFF
--- a/datafiles/shared_enums.json
+++ b/datafiles/shared_enums.json
@@ -134,6 +134,9 @@
         "name": "float80:FLOAT80"
       },
       {
+        "name": "bfloat16:BFLOAT16"
+      },
+      {
         "name": "bfloat16x2:BFLOAT16X2"
       },
       {


### PR DESCRIPTION
## Summary

BF16 operands across the AVX-NE-CONVERT and AVX512_BF16/AMX_BF16 instructions were typed as generic integers, or as `float80` for the pair-load memory operands. Single BF16 elements now use a new scalar `bfloat16` element type and packed BF16 pairs use `bfloat16x2`, mirroring the `float16`/`float16x2` typing of the FP16 AVX-NE-CONVERT siblings.

## Changes

- Add a scalar `bfloat16` member to the element-type enum.
- `vbcstnebf162ps`: memory source operand `uint16` -> `bfloat16`.
- `vcvtneps2bf16`, `vcvtne2ps2bf16`: destination register operand `uint16` -> `bfloat16`.
- `vdpbf16ps`, `tdpbf16ps`: BF16-pair source operands `uint32` -> `bfloat16x2`.
- `vcvtneebf162ps`, `vcvtneobf162ps`: memory source operand `float80` -> `bfloat16x2`.

## Related

- zyantific/zydis#642 adds the matching `ZYDIS_IELEMENT_TYPE_BFLOAT16` on the library side; it needs to merge before tables regenerated from this change land there.
