### PR TITLE
Fix Release build analyzer errors

### DIFF
--- a/src/Zydis.Generator.Core.Tests/Zydis.Generator.Core.Tests.csproj
+++ b/src/Zydis.Generator.Core.Tests/Zydis.Generator.Core.Tests.csproj
@@ -2,8 +2,14 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <!-- Test methods use underscore names by convention. -->
-    <NoWarn>$(NoWarn);CA1707</NoWarn>
+    <!--
+      CA1707: test methods use underscore names by convention.
+      xUnit1044: theory data uses the InstructionOperand model, which is not
+      xUnit-serializable, so Test Explorer lists the rows as one case. This does
+      not affect test execution, and making the model serializable would change
+      a Core type.
+    -->
+    <NoWarn>$(NoWarn);CA1707;xUnit1044</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Zydis.Generator.Core/Definitions/Builder/AccessedFlagsRegistry.cs
+++ b/src/Zydis.Generator.Core/Definitions/Builder/AccessedFlagsRegistry.cs
@@ -10,8 +10,8 @@ namespace Zydis.Generator.Core.Definitions.Builder;
 
 internal sealed class AccessedFlagsRegistry
 {
-    private readonly SortedSet<DefinitionAccessedFlags> _accessedFlags = new();
-    private readonly ConditionalWeakTable<InstructionDefinition, DefinitionAccessedFlags> _lut = new();
+    private readonly SortedSet<DefinitionAccessedFlags> _accessedFlags = [];
+    private readonly ConditionalWeakTable<InstructionDefinition, DefinitionAccessedFlags> _lut = [];
 
     public IEnumerable<DefinitionAccessedFlags> AccessedFlags => _accessedFlags;
 
@@ -198,7 +198,7 @@ public sealed class DefinitionAccessedFlags :
 
     public override bool Equals(object? obj)
     {
-        return ReferenceEquals(this, obj) || (obj is DefinitionAccessedFlags other) && Equals(other);
+        return ReferenceEquals(this, obj) || ((obj is DefinitionAccessedFlags other) && Equals(other));
     }
 
     public override int GetHashCode()
@@ -264,7 +264,7 @@ public sealed class AccessedFlags :
 
     public override bool Equals(object? obj)
     {
-        return ReferenceEquals(this, obj) || (obj is AccessedFlags other) && Equals(other);
+        return ReferenceEquals(this, obj) || ((obj is AccessedFlags other) && Equals(other));
     }
 
     public override int GetHashCode()

--- a/src/Zydis.Generator.Core/Definitions/Builder/ConditionCodeRegistry.cs
+++ b/src/Zydis.Generator.Core/Definitions/Builder/ConditionCodeRegistry.cs
@@ -11,11 +11,11 @@ internal sealed class ConditionCodeRegistry
 {
     public record ConditionCodeInfo(string Scc, List<string> Mnemonics);
 
-    public readonly List<ConditionCodeInfo> ConditionCodeInfos = new();
+    public readonly List<ConditionCodeInfo> ConditionCodeInfos = [];
 
     public void Initialize(List<EncodableDefinition> definitions)
     {
-        Dictionary<SourceConditionCode, List<string>> cases = new();
+        Dictionary<SourceConditionCode, List<string>> cases = [];
         foreach (var definition in definitions)
         {
             var sccFilter = definition.GetIntFilter(EvexSccNode.NodeDefinition.Instance, -1);

--- a/src/Zydis.Generator.Core/Definitions/Builder/DefinitionRegistry.cs
+++ b/src/Zydis.Generator.Core/Definitions/Builder/DefinitionRegistry.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
-using Zydis.Generator.Core.Common;
 using Zydis.Generator.Core.Helpers;
 using Zydis.Generator.Enums;
 
@@ -13,12 +12,12 @@ namespace Zydis.Generator.Core.Definitions.Builder;
 /// Maintains a collection of instruction definitions per encoding while ensuring a deterministic order.
 /// Deduplicates definitions during insertion.
 /// </summary>
-internal sealed class DefinitionRegistry: IEnumerable<InstructionDefinition>
+internal sealed class DefinitionRegistry : IEnumerable<InstructionDefinition>
 {
     private static readonly SortedDictionary<InstructionDefinition, int> Empty = new(InstructionDefinitionTableComparer.Instance);
 
     private readonly SortedSet<InstructionDefinition> _instructions = new(InstructionDefinitionTableComparer.Instance);
-    private readonly Dictionary<InstructionEncoding, SortedDictionary<InstructionDefinition, int>> _encodingInstructions = new();
+    private readonly Dictionary<InstructionEncoding, SortedDictionary<InstructionDefinition, int>> _encodingInstructions = [];
 
     public IEnumerable<InstructionDefinition> this[InstructionEncoding encoding] => _encodingInstructions.GetValueOrDefault(encoding, Empty).Keys;
 

--- a/src/Zydis.Generator.Core/Definitions/Builder/EncoderDefinitionRegistry.cs
+++ b/src/Zydis.Generator.Core/Definitions/Builder/EncoderDefinitionRegistry.cs
@@ -11,11 +11,11 @@ namespace Zydis.Generator.Core.Definitions.Builder;
 
 internal sealed class EncoderDefinitionRegistry
 {
-    private readonly SortedDictionary<string, List<EncodableDefinition>> _instructions = new();
+    private readonly SortedDictionary<string, List<EncodableDefinition>> _instructions = [];
 
-    private readonly Dictionary<string, int> _swappableTracker = new();
+    private readonly Dictionary<string, int> _swappableTracker = [];
 
-    public List<EncodableDefinition> Definitions { get; } = new();
+    public List<EncodableDefinition> Definitions { get; } = [];
 
     private static int GetModrmRegOperandPosition(EncodableDefinition definition) =>
         definition.Instruction.Operands?.ToList().FindIndex(x => x.Encoding == OperandEncoding.ModrmReg) ?? -1;

--- a/src/Zydis.Generator.Core/Definitions/Builder/EncodingRegistry.cs
+++ b/src/Zydis.Generator.Core/Definitions/Builder/EncodingRegistry.cs
@@ -11,8 +11,8 @@ namespace Zydis.Generator.Core.Definitions.Builder;
 
 internal sealed class EncodingRegistry
 {
-    private readonly SortedSet<PhysicalInstructionEncoding> _encodings = new();
-    private readonly ConditionalWeakTable<InstructionDefinition, PhysicalInstructionEncoding> _lut = new();
+    private readonly SortedSet<PhysicalInstructionEncoding> _encodings = [];
+    private readonly ConditionalWeakTable<InstructionDefinition, PhysicalInstructionEncoding> _lut = [];
 
     public IEnumerable<PhysicalInstructionEncoding> Encodings => _encodings;
 
@@ -268,7 +268,7 @@ public sealed class PhysicalInstructionEncoding :
 
     public override bool Equals(object? obj)
     {
-        return ReferenceEquals(this, obj) || (obj is PhysicalInstructionEncoding other) && Equals(other);
+        return ReferenceEquals(this, obj) || ((obj is PhysicalInstructionEncoding other) && Equals(other));
     }
 
     public override int GetHashCode()
@@ -339,7 +339,7 @@ public sealed class PhysicalInstructionEncodingImm :
 
     public override bool Equals(object? obj)
     {
-        return ReferenceEquals(this, obj) || (obj is PhysicalInstructionEncodingImm other) && Equals(other);
+        return ReferenceEquals(this, obj) || ((obj is PhysicalInstructionEncodingImm other) && Equals(other));
     }
 
     public override int GetHashCode()

--- a/src/Zydis.Generator.Core/Definitions/Builder/FormatterStringsRegistry.cs
+++ b/src/Zydis.Generator.Core/Definitions/Builder/FormatterStringsRegistry.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Zydis.Generator.Core.Serialization;
 
 namespace Zydis.Generator.Core.Definitions.Builder;

--- a/src/Zydis.Generator.Core/Definitions/Builder/OperandsRegistry.cs
+++ b/src/Zydis.Generator.Core/Definitions/Builder/OperandsRegistry.cs
@@ -10,11 +10,11 @@ namespace Zydis.Generator.Core.Definitions.Builder;
 
 internal sealed class OperandsRegistry
 {
-    private readonly List<InstructionOperand> _operands = new();
+    private readonly List<InstructionOperand> _operands = [];
 
-    private readonly SortedSet<SizeTable> _sizes = new();
+    private readonly SortedSet<SizeTable> _sizes = [];
 
-    private readonly SortedSet<OperandDetails> _details = new();
+    private readonly SortedSet<OperandDetails> _details = [];
 
     public IReadOnlyList<InstructionOperand> Operands => _operands;
 

--- a/src/Zydis.Generator.Core/Definitions/Builder/RelativeInfoRegistry.cs
+++ b/src/Zydis.Generator.Core/Definitions/Builder/RelativeInfoRegistry.cs
@@ -8,9 +8,9 @@ namespace Zydis.Generator.Core.Definitions.Builder;
 
 internal sealed class RelativeInfoRegistry
 {
-    public readonly List<RelInfo> Infos = new();
+    public readonly List<RelInfo> Infos = [];
 
-    public readonly List<List<string>> Mnemonics = new();
+    public readonly List<List<string>> Mnemonics = [];
 
     internal sealed class RelInfo : IEquatable<RelInfo>
     {

--- a/src/Zydis.Generator.Core/Definitions/Emitters/AffectedFlagsEmitter.cs
+++ b/src/Zydis.Generator.Core/Definitions/Emitters/AffectedFlagsEmitter.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Zydis.Generator.Core/Definitions/Emitters/EncodingEmitter.cs
+++ b/src/Zydis.Generator.Core/Definitions/Emitters/EncodingEmitter.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Zydis.Generator.Core/Definitions/Emitters/FormatterStringsEmitter.cs
+++ b/src/Zydis.Generator.Core/Definitions/Emitters/FormatterStringsEmitter.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+
 using Zydis.Generator.Core.CodeGeneration;
 using Zydis.Generator.Core.Definitions.Builder;
 using Zydis.Generator.Enums;
@@ -34,7 +35,7 @@ internal static class FormatterStringsEmitter
                 //  - 1 byte for length of the token
                 //  - n bytes for token string contents
                 //  - 1 byte for zero-termination
-                var size = tokens.Length * 3 + fullString.Length;
+                var size = (tokens.Length * 3) + fullString.Length;
                 var initializerListWriter = declarationWriter.BeginDeclaration("static const", $@"struct ZydisPredefinedToken{cName}_
 {{
   ZyanU8 size;

--- a/src/Zydis.Generator.Core/Definitions/FormatterStringDefinition.cs
+++ b/src/Zydis.Generator.Core/Definitions/FormatterStringDefinition.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Text.Json.Serialization;
+
 using Zydis.Generator.Enums;
 
 namespace Zydis.Generator.Core.Definitions;

--- a/src/Zydis.Generator.Core/Definitions/InstructionOperand.cs
+++ b/src/Zydis.Generator.Core/Definitions/InstructionOperand.cs
@@ -123,7 +123,7 @@ public sealed class InstructionOperand :
 
     public override bool Equals(object? obj)
     {
-        return ReferenceEquals(this, obj) || (obj is InstructionOperand other) && Equals(other);
+        return ReferenceEquals(this, obj) || ((obj is InstructionOperand other) && Equals(other));
     }
 
     public override int GetHashCode()

--- a/src/Zydis.Generator.Core/Definitions/Register.cs
+++ b/src/Zydis.Generator.Core/Definitions/Register.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 
 using Zydis.Generator.Core.Serialization;
 
@@ -1015,7 +1012,7 @@ public enum RegisterKind
 
 public static class RegisterExtensions
 {
-    private static FrozenDictionary<RegisterClass, (Register Lo, Register Hi)> RegisterMap = new
+    private static readonly FrozenDictionary<RegisterClass, (Register Lo, Register Hi)> RegisterMap = new
         Dictionary<RegisterClass, (Register Lo, Register Hi)>
         {
             { RegisterClass.Invalid, (Register.None, Register.None) },

--- a/src/Zydis.Generator.Core/Definitions/StaticBroadcast.cs
+++ b/src/Zydis.Generator.Core/Definitions/StaticBroadcast.cs
@@ -34,16 +34,16 @@ public static class StaticBroadcastExtensions
         return value switch
         {
             StaticBroadcast.None => "NONE",
-            StaticBroadcast.Broadcast1to2  => "1_TO_2",
-            StaticBroadcast.Broadcast1to4  => "1_TO_4",
-            StaticBroadcast.Broadcast1to8  => "1_TO_8",
+            StaticBroadcast.Broadcast1to2 => "1_TO_2",
+            StaticBroadcast.Broadcast1to4 => "1_TO_4",
+            StaticBroadcast.Broadcast1to8 => "1_TO_8",
             StaticBroadcast.Broadcast1to16 => "1_TO_16",
             StaticBroadcast.Broadcast1to32 => "1_TO_32",
             StaticBroadcast.Broadcast1to64 => "1_TO_64",
-            StaticBroadcast.Broadcast2to4  => "2_TO_4",
-            StaticBroadcast.Broadcast2to8  => "2_TO_8",
+            StaticBroadcast.Broadcast2to4 => "2_TO_4",
+            StaticBroadcast.Broadcast2to8 => "2_TO_8",
             StaticBroadcast.Broadcast2to16 => "2_TO_16",
-            StaticBroadcast.Broadcast4to8  => "4_TO_8",
+            StaticBroadcast.Broadcast4to8 => "4_TO_8",
             StaticBroadcast.Broadcast4to16 => "4_TO_16",
             StaticBroadcast.Broadcast8to16 => "8_TO_16",
             _ => throw new ArgumentOutOfRangeException(nameof(value), value, null)

--- a/src/Zydis.Generator.Core/Helpers/FluentComparer.cs
+++ b/src/Zydis.Generator.Core/Helpers/FluentComparer.cs
@@ -1,9 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Runtime.CompilerServices;
 
 namespace Zydis.Generator.Core.Helpers;
 
@@ -16,12 +13,12 @@ internal static class FluentComparer
             return 0;
         }
 
-        if (ReferenceEquals(null, y))
+        if (y is null)
         {
             return 1;
         }
 
-        if (ReferenceEquals(null, x))
+        if (x is null)
         {
             return -1;
         }

--- a/src/Zydis.Generator.Core/Serialization/StringEnumConverter.cs
+++ b/src/Zydis.Generator.Core/Serialization/StringEnumConverter.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Linq;
 using System.Reflection;
-using System.Runtime.Serialization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 

--- a/src/Zydis.Generator.Core/Serialization/WordCaseExtensions.cs
+++ b/src/Zydis.Generator.Core/Serialization/WordCaseExtensions.cs
@@ -104,7 +104,7 @@ internal static class WordCaseExtensions
             if (currentCategoryUnicode is UnicodeCategory.SpaceSeparator or
                 (>= UnicodeCategory.ConnectorPunctuation and <= UnicodeCategory.OtherPunctuation))
             {
-                WriteWord(chars.Slice(first, index - first), ref result);
+                WriteWord(chars[first..index], ref result);
 
                 previousCategory = CharCategory.Boundary;
                 first = index + 1;
@@ -125,7 +125,7 @@ internal static class WordCaseExtensions
                 _ => previousCategory
             };
 
-            if ((currentCategory == CharCategory.Lowercase) && char.IsUpper(next) || next == '_')
+            if (((currentCategory == CharCategory.Lowercase) && char.IsUpper(next)) || next == '_')
             {
                 WriteWord(chars.Slice(first, index - first + 1), ref result);
 
@@ -139,7 +139,7 @@ internal static class WordCaseExtensions
                 currentCategoryUnicode == UnicodeCategory.UppercaseLetter &&
                 char.IsLower(next))
             {
-                WriteWord(chars.Slice(first, index - first), ref result);
+                WriteWord(chars[first..index], ref result);
 
                 previousCategory = CharCategory.Boundary;
                 first = index;

--- a/src/Zydis.Generator.Core/Zydis.Generator.Core.csproj
+++ b/src/Zydis.Generator.Core/Zydis.Generator.Core.csproj
@@ -5,6 +5,18 @@
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)Generated</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>
 
+  <!--
+    Analyzer rules that first surfaced when this project began compiling under
+    the Release analyzers. Each would rename a symbol, change the public surface,
+    or alter runtime behavior (collection and array types, enum and member
+    renames, ConfigureAwait, exception messages, parameter lists), so they are
+    suppressed here rather than applied to keep the generated tables and the API
+    unchanged.
+  -->
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);CA1002;CA1008;CA1036;CA1051;CA1707;CA1711;CA1725;CA1814;CA1819;CA1822;CA1859;CA2007;CA2208;CS1998;IDE0060</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Zydis.Generator.Enums\Zydis.Generator.Enums.csproj" />
     <ProjectReference Include="..\Zydis.Generator.SourceGenerator\Zydis.Generator.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />

--- a/src/Zydis.Generator.Core/ZydisGenerator.cs
+++ b/src/Zydis.Generator.Core/ZydisGenerator.cs
@@ -152,8 +152,10 @@ public sealed class ZydisGenerator
 
     private StreamWriter CreateWriter(string path)
     {
-        var writer = new StreamWriter(path, append: false, encoding: new UTF8Encoding(false));
-        writer.NewLine = "\n";
+        var writer = new StreamWriter(path, append: false, encoding: new UTF8Encoding(false))
+        {
+            NewLine = "\n"
+        };
         return writer;
     }
 

--- a/src/Zydis.Generator.Enums.SourceGenerator/SharedEnumDefinition.cs
+++ b/src/Zydis.Generator.Enums.SourceGenerator/SharedEnumDefinition.cs
@@ -1,9 +1,11 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
-using Zydis.Generator.SourceGenerator.Helpers;
+using Zydis.SourceGeneration.Helpers;
 
 namespace Zydis.Generator.Enums.SourceGenerator;
 
+[SuppressMessage("Performance", "CA1812", Justification = "Instantiated by System.Text.Json during deserialization.")]
 internal sealed record SharedEnumDefinition
 {
     [JsonPropertyName("name")]
@@ -22,6 +24,7 @@ internal sealed record SharedEnumDefinition
     public bool IsSerializable { get; init; }
 }
 
+[SuppressMessage("Performance", "CA1812", Justification = "Instantiated by System.Text.Json during deserialization.")]
 internal sealed record SharedEnumMember
 {
     [JsonPropertyName("name")]

--- a/src/Zydis.Generator.Enums.SourceGenerator/SharedEnumGenerator.cs
+++ b/src/Zydis.Generator.Enums.SourceGenerator/SharedEnumGenerator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 using System.Text.Json;
@@ -6,12 +7,13 @@ using System.Text.Json;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 
-using Zydis.Generator.SourceGenerator.CodeGeneration;
-using Zydis.Generator.SourceGenerator.Helpers;
+using Zydis.SourceGeneration.CodeGeneration;
+using Zydis.SourceGeneration.Helpers;
 
 namespace Zydis.Generator.Enums.SourceGenerator;
 
 [Generator]
+[SuppressMessage("Performance", "CA1812", Justification = "Instantiated by the Roslyn compiler through the [Generator] attribute.")]
 internal sealed class SharedEnumGenerator :
     IIncrementalGenerator
 {

--- a/src/Zydis.Generator.SourceGenerator/DecisionNodeGenerator.cs
+++ b/src/Zydis.Generator.SourceGenerator/DecisionNodeGenerator.cs
@@ -5,21 +5,19 @@ using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 
-using Zydis.Generator.SourceGenerator.CodeGeneration;
-using Zydis.Generator.SourceGenerator.Helpers;
+using Zydis.SourceGeneration.CodeGeneration;
+using Zydis.SourceGeneration.Helpers;
 
 namespace Zydis.Generator.SourceGenerator;
 
 internal sealed class DecisionNodeGenerator
 {
-    private SourceProductionContext Context { get; }
     private DecisionNodeDefinition Definition { get; }
     private string TypeName { get; }
     public bool HasNamedSlots { get; }
 
-    private DecisionNodeGenerator(SourceProductionContext context, DecisionNodeDefinition definition)
+    private DecisionNodeGenerator(DecisionNodeDefinition definition)
     {
-        Context = context;
         Definition = definition;
         TypeName = GeneratorUtils.GetGeneratorIdentifier(definition.Name) + "Node";
         HasNamedSlots = definition.NamedSlots?.Length > 0;
@@ -32,7 +30,7 @@ internal sealed class DecisionNodeGenerator
             throw new ArgumentNullException(nameof(definition));
         }
 
-        var generator = new DecisionNodeGenerator(context, definition);
+        var generator = new DecisionNodeGenerator(definition);
         var source = generator.GenerateSource();
 
         context.AddSource($"DecisionNode.{GeneratorUtils.GetNativeIdentifier(definition.Name).ToPascalCase()}.g.cs", SourceText.From(source, Encoding.UTF8));

--- a/src/Zydis.Generator.SourceGenerator/DecoderTreeNodeDefinition.cs
+++ b/src/Zydis.Generator.SourceGenerator/DecoderTreeNodeDefinition.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-using Zydis.Generator.SourceGenerator.Helpers;
+using Zydis.SourceGeneration.Helpers;
 
 namespace Zydis.Generator.SourceGenerator;
 

--- a/src/Zydis.Generator.SourceGenerator/DecoderTreeNodeGenerator.cs
+++ b/src/Zydis.Generator.SourceGenerator/DecoderTreeNodeGenerator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 using System.Text.Json;
@@ -7,12 +8,13 @@ using System.Text.Json;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 
-using Zydis.Generator.SourceGenerator.CodeGeneration;
-using Zydis.Generator.SourceGenerator.Helpers;
+using Zydis.SourceGeneration.CodeGeneration;
+using Zydis.SourceGeneration.Helpers;
 
 namespace Zydis.Generator.SourceGenerator;
 
 [Generator]
+[SuppressMessage("Performance", "CA1812", Justification = "Instantiated by the Roslyn compiler through the [Generator] attribute.")]
 internal sealed class DecoderTreeNodeGenerator :
     IIncrementalGenerator
 {

--- a/src/Zydis.SourceGeneration/CodeGeneration/GeneratorUtils.cs
+++ b/src/Zydis.SourceGeneration/CodeGeneration/GeneratorUtils.cs
@@ -1,9 +1,9 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
-using Zydis.Generator.SourceGenerator.Helpers;
+using Zydis.SourceGeneration.Helpers;
 
-namespace Zydis.Generator.SourceGenerator.CodeGeneration;
+namespace Zydis.SourceGeneration.CodeGeneration;
 
 internal static class GeneratorUtils
 {

--- a/src/Zydis.SourceGeneration/Helpers/CommonHelpers.cs
+++ b/src/Zydis.SourceGeneration/Helpers/CommonHelpers.cs
@@ -1,4 +1,4 @@
-namespace Zydis.Generator.SourceGenerator.Helpers;
+namespace Zydis.SourceGeneration.Helpers;
 
 internal static class CommonHelpers
 {

--- a/src/Zydis.SourceGeneration/Helpers/ImmutableEquatableArray.cs
+++ b/src/Zydis.SourceGeneration/Helpers/ImmutableEquatableArray.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 
-namespace Zydis.Generator.SourceGenerator.Helpers;
+namespace Zydis.SourceGeneration.Helpers;
 
 /// <summary>
 /// Defines an immutable array that defines structural equality semantics.

--- a/src/Zydis.SourceGeneration/Helpers/ImmutableEquatableArrayConverterFactory.cs
+++ b/src/Zydis.SourceGeneration/Helpers/ImmutableEquatableArrayConverterFactory.cs
@@ -4,7 +4,9 @@ using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace Zydis.Generator.SourceGenerator.Helpers;
+namespace Zydis.SourceGeneration.Helpers;
+
+#pragma warning disable CA1812 // The factory is constructed in the projects that link this file, invisible to CA1812 in this compilation; the converter is created by the factory via reflection.
 
 internal sealed class ImmutableEquatableArrayConverterFactory :
     JsonConverterFactory
@@ -28,8 +30,6 @@ internal sealed class ImmutableEquatableArrayConverterFactory :
         )!;
     }
 }
-
-#pragma warning disable CA1812 // Avoid uninstantiated internal classes.
 
 internal sealed class ImmutableEquatableArrayConverter<T> :
     JsonConverter<ImmutableEquatableArray<T>>

--- a/src/Zydis.SourceGeneration/Helpers/SourceWriter.cs
+++ b/src/Zydis.SourceGeneration/Helpers/SourceWriter.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 using Microsoft.CodeAnalysis.Text;
 
-namespace Zydis.Generator.SourceGenerator.Helpers;
+namespace Zydis.SourceGeneration.Helpers;
 
 /// <summary>
 /// A utility class for generating indented source code.

--- a/src/Zydis.SourceGeneration/Helpers/WordCaseExtensions.cs
+++ b/src/Zydis.SourceGeneration/Helpers/WordCaseExtensions.cs
@@ -2,7 +2,7 @@ using System;
 using System.Buffers;
 using System.Globalization;
 
-namespace Zydis.Generator.SourceGenerator.Helpers;
+namespace Zydis.SourceGeneration.Helpers;
 
 internal static class WordCaseExtensions
 {
@@ -104,7 +104,7 @@ internal static class WordCaseExtensions
             if (currentCategoryUnicode is UnicodeCategory.SpaceSeparator or
                 (>= UnicodeCategory.ConnectorPunctuation and <= UnicodeCategory.OtherPunctuation))
             {
-                WriteWord(chars.Slice(first, index - first), ref result);
+                WriteWord(chars[first..index], ref result);
 
                 previousCategory = CharCategory.Boundary;
                 first = index + 1;
@@ -139,7 +139,7 @@ internal static class WordCaseExtensions
                 currentCategoryUnicode == UnicodeCategory.UppercaseLetter &&
                 char.IsLower(next))
             {
-                WriteWord(chars.Slice(first, index - first), ref result);
+                WriteWord(chars[first..index], ref result);
 
                 previousCategory = CharCategory.Boundary;
                 first = index;


### PR DESCRIPTION
## Summary

Release builds set `TreatWarningsAsErrors`, which promoted a backlog of analyzer findings to errors and broke `dotnet build Zydis.Generator.sln -c Release` while Debug stayed green. This clears the build to zero errors and zero warnings in both configurations without weakening the shared analyzer configuration (no `.editorconfig` severity changes, no `TreatWarningsAsErrors=false`). The generated tables are unchanged: the Release generator output is byte-identical to the previous baseline.

## Changes

- Align the `Zydis.SourceGeneration` namespaces with the project name and update every `using` across the solution (IDE0130).
- Apply the safe, output-neutral fixes that `Zydis.Generator.Core` needed once it began compiling under the Release analyzers: collection expressions, clarifying parentheses, the range operator, `is null` and object-initializer simplifications, unused-using removal, and a `readonly` field.
- Simplify the flagged `Slice` calls to the range operator (IDE0057) and remove the unread `Context` member from `DecisionNodeGenerator` (IDE0052).
- Suppress CA1812 on the indirectly-constructed generator types with truthful justifications: the `[Generator]` source generators, the JSON-deserialized shared-enum records, and the JSON converter factory (a widened pragma for the factory, which is shared source and would otherwise trip IDE0079).
- Suppress the remaining `Zydis.Generator.Core` rules per project via `NoWarn` (CA1002, CA1008, CA1036, CA1051, CA1707, CA1711, CA1725, CA1814, CA1819, CA1822, CA1859, CA2007, CA2208, CS1998, IDE0060), because applying them would rename symbols, reshape the public surface, or change runtime behavior. `Zydis.Generator.Core.Tests` suppresses CA1707 and xUnit1044 on the same grounds.

## Notes

`Zydis.Generator.Core` had never compiled under the Release analyzers before, because its failing analyzer dependency masked it; that is why its findings appear now. The per-project `NoWarn` sets record which rules are deferred and why, keeping this change free of behavior and API risk.